### PR TITLE
Extra check if ROMS_AVERAGES is defined in getFieldData

### DIFF
--- a/src/FISOC_OM_Wrapper_ROMS.f90
+++ b/src/FISOC_OM_Wrapper_ROMS.f90
@@ -551,7 +551,9 @@ CONTAINS
     USE mod_param, ONLY       : BOUNDS, Ngrids
     USE mod_stepping, ONLY    : nnew
     USE mod_grid , ONLY       : GRID
+#if defined(ROMS_AVERAGES)
     USE mod_average, ONLY     : AVERAGE
+#endif
 
     IMPLICIT NONE
 


### PR DESCRIPTION
Adds another preprocessor check for whether to use the ROMS average
module; without this, FISOC won't compile with averaging off.